### PR TITLE
Fix typo event to e in record_and_play

### DIFF
--- a/web/record_and_play/index.html
+++ b/web/record_and_play/index.html
@@ -144,23 +144,23 @@
             $(img).on('touchstart vmousedown', function(e) {
                 touching = true;
                 ratio = naturalWidth / img.width();
-                x = (event.pageX - img.offset().left) * ratio;
-                y = (event.pageY - img.offset().top) * ratio;
+                x = (e.pageX - img.offset().left) * ratio;
+                y = (e.pageY - img.offset().top) * ratio;
                 update(x, y);
                 addlog(x, y);
             })
 
             $(img).on('touchmove vmousemove', function(e) {
                 ratio = naturalWidth / img.width();
-                x = (event.pageX - img.offset().left) * ratio;
-                y = (event.pageY - img.offset().top) * ratio;
+                x = (e.pageX - img.offset().left) * ratio;
+                y = (e.pageY - img.offset().top) * ratio;
                 update(x, y);
             })
 
             $(img).on('touchend vmouseup vmouseout', function(e) {
                 touching = false;
-                x = (event.pageX - img.offset().left) * ratio;
-                y = (event.pageY - img.offset().top) * ratio;
+                x = (e.pageX - img.offset().left) * ratio;
+                y = (e.pageY - img.offset().top) * ratio;
                 update(x, y);
             });
 


### PR DESCRIPTION
This didn't work for me and produced errors in the console.
After this change no errors are produced and I can move the arm.